### PR TITLE
Fixed echo message under install_deps_openSUSE

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -53,7 +53,7 @@ install_deps_arch:
 	
 install_deps_openSUSE:
 	sudo zypper install gcc qemu virtualbox nasm grub xorriso mtools
-	@echo You have to install gcc-g++ form yor browser for your SUSE
+	@echo You have to install gcc-g++ from your browser for your SUSE
 install_deps_RedHat:
 
 archive:


### PR DESCRIPTION
Hello! Really cool project. :slightly_smiling_face:
I was going through the `Makefile` and found this in [line 56](https://github.com/DSC-KIIT/project-halide/blob/master/src/Makefile#L56):
```sh
	@echo You have to install gcc-g++ form yor browser for your SUSE
```
So, I fixed the spellings a bit:
```sh
	@echo You have to install gcc-g++ from your browser for your SUSE
```
Cheers!