### PR TITLE
Added .gitignore inside src and removed objs

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,5 @@
+diskImage
+objs
+*.o
+*.iso
+*.bin


### PR DESCRIPTION
I added `src/.gitignore` so that `git` does not track the binaries, who even tracks binaries lol?! We should probably put the binaries in the releases.