### PR TITLE
Removed configure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: configure
-      run: ./configure
     - name: making kernel.iso
       run: |
         cd src


### PR DESCRIPTION
When I made the workflow, I didn't notice that there wasn't a `configure` script. So, here's a fix! :slightly_smiling_face: 